### PR TITLE
agree with remote terminus on snd-settle-mode

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -393,7 +393,7 @@ impl SessionInner {
                             name: attach.name.clone(),
                             handle: token as Handle,
                             role: Role::Receiver,
-                            snd_settle_mode: SenderSettleMode::Mixed,
+                            snd_settle_mode: attach.snd_settle_mode(),
                             rcv_settle_mode: ReceiverSettleMode::First,
                             source: attach.source.clone(),
                             target: attach.target.clone(),


### PR DESCRIPTION
*amqp 1.0 spec*
```
snd-settle-mode
The delivery settlement policy for the sender. When set at the receiver
this indicates the desired value for the settlement mode at the sender.
When set at the sender this indicates the actual settlement mode in use.
```

It should not matter what the local terminus sends back when the attach
is initiated by a remote terminus. The sender sets the actual settlement
mode.

However some AMQP clients incorrectly change their send settlement mode
based on this response. This change makes the attach response use the
same mode to deal with such clients. Compliant clients will ignore this
field in the response.