### PR TITLE
connection close handling improvements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 # Changes
 
+## [0.5.9] - 2021-12-14
+
+* Send the close frame in close and close_with_error
+* Allow the control service to handle remote_close
+* Propagate IO errors
+* Change dispatcher trait bounds to allow different error types from Sr and Ctl
+* Hold shutdown of dispatcher until control service has handled the close control message
+* Add client start with custom control service
+
 ## [0.5.8] - 2021-12-14
 
 * Cleanup session end flow #17

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ntex-amqp"
-version = "0.5.8"
+version = "0.5.9"
 authors = ["ntex contributors <team@ntex.rs>"]
 description = "AMQP 1.0 Client/Server framework"
 documentation = "https://docs.rs/ntex-amqp"

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -95,20 +95,25 @@ impl Connection {
 
     /// Gracefully close connection
     pub fn close(&self) -> impl Future<Output = Result<(), AmqpProtocolError>> {
-        self.0.get_ref().io.close();
+        let inner = self.0.get_mut();
+        inner.post_frame(AmqpFrame::new(0, Frame::Close(Close { error: None })));
+        inner.io.close();
         Ready::Ok(())
     }
 
-    // TODO: implement
     /// Close connection with error
-    pub fn close_with_error<E>(
-        &self,
-        _err: &E,
-    ) -> impl Future<Output = Result<(), AmqpProtocolError>>
+    pub fn close_with_error<E>(&self, err: E) -> impl Future<Output = Result<(), AmqpProtocolError>>
     where
         Error: From<E>,
     {
-        self.0.get_ref().io.close();
+        let inner = self.0.get_mut();
+        inner.post_frame(AmqpFrame::new(
+            0,
+            Frame::Close(Close {
+                error: Some(err.into()),
+            }),
+        ));
+        inner.io.close();
         Ready::Ok(())
     }
 
@@ -192,6 +197,9 @@ impl ConnectionInner {
     }
 
     pub(crate) fn post_frame(&mut self, frame: AmqpFrame) {
+        #[cfg(feature = "frame-trace")]
+        log::trace!("outgoing: {:#?}", frame);
+
         if let Err(e) = self.io.write().encode(frame, &self.codec) {
             self.set_error(e.into());
         }
@@ -291,18 +299,19 @@ impl ConnectionInner {
                 return Ok(Action::None);
             }
             Frame::Close(close) => {
-                self.set_error(AmqpProtocolError::Closed(close.error.clone()));
-
                 if self.state == ConnectionState::Closing {
                     log::trace!("Connection closed: {:?}", close);
                     self.set_error(AmqpProtocolError::Disconnected);
+                    return Ok(Action::None);
                 } else {
                     log::trace!("Connection closed remotely: {:?}", close);
+                    let err = AmqpProtocolError::Closed(close.error.clone());
+                    self.set_error(err.clone());
                     let close = Close { error: None };
                     self.post_frame(AmqpFrame::new(0, close.into()));
                     self.state = ConnectionState::RemoteClose;
+                    return Ok(Action::RemoteClose(err));
                 }
-                return Ok(Action::None);
             }
             Frame::Begin(begin) => {
                 // response Begin for open session

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -1,4 +1,4 @@
-use std::{cell, fmt, future::Future, marker, pin::Pin, task::Context, task::Poll};
+use std::{cell, fmt, future::Future, marker, pin::Pin, rc::Rc, task::Context, task::Poll};
 
 use ntex::framed::DispatchItem;
 use ntex::service::Service;
@@ -16,7 +16,7 @@ pub(crate) struct Dispatcher<Sr: Service, Ctl: Service> {
     service: Sr,
     ctl_service: Ctl,
     ctl_fut: cell::RefCell<Option<(Option<ControlFrame>, Pin<Box<Ctl::Future>>)>>,
-    shutdown: cell::Cell<bool>,
+    shutdown: cell::RefCell<Option<Pin<Box<Ctl::Future>>>>,
     expire: Sleep,
     idle_timeout: Millis,
 }
@@ -24,11 +24,10 @@ pub(crate) struct Dispatcher<Sr: Service, Ctl: Service> {
 impl<Sr, Ctl> Dispatcher<Sr, Ctl>
 where
     Sr: Service<Request = types::Message, Response = ()>,
-    Sr::Error: 'static,
+    Sr::Error: Into<Error> + 'static,
     Sr::Future: 'static,
     Ctl: Service<Request = ControlFrame, Response = ()>,
-    Ctl::Error: 'static,
-    Error: From<Sr::Error> + From<Ctl::Error>,
+    Ctl::Error: Into<Error> + 'static,
 {
     pub(crate) fn new(
         sink: Connection,
@@ -42,7 +41,7 @@ where
             ctl_service,
             idle_timeout,
             ctl_fut: cell::RefCell::new(None),
-            shutdown: cell::Cell::new(false),
+            shutdown: cell::RefCell::new(None),
             expire: sleep(idle_timeout),
         }
     }
@@ -124,7 +123,7 @@ where
                     let fut = self.service.call(types::Message::Attached(link.clone()));
                     ntex::rt::spawn(async move {
                         if let Err(err) = fut.await {
-                            let _ = link.close_with_error(Error::from(err)).await;
+                            let _ = link.close_with_error(err.into()).await;
                         } else {
                             link.confirm_receiver_link();
                             link.set_link_credit(50);
@@ -163,12 +162,11 @@ where
 impl<Sr, Ctl> Service for Dispatcher<Sr, Ctl>
 where
     Sr: Service<Request = types::Message, Response = ()>,
-    Sr::Error: fmt::Debug + 'static,
+    Sr::Error: Into<Error> + fmt::Debug + 'static,
     Sr::Future: 'static,
     Ctl: Service<Request = ControlFrame, Response = ()>,
-    Ctl::Error: fmt::Debug + 'static,
+    Ctl::Error: Into<Error> + fmt::Debug + 'static,
     Ctl::Future: 'static,
-    Error: From<Sr::Error> + From<Ctl::Error>,
 {
     type Request = DispatchItem<AmqpCodec<AmqpFrame>>;
     type Response = ();
@@ -176,6 +174,7 @@ where
     type Future = Either<ServiceResult<Sr::Future, Sr::Error>, Ready<Self::Response, Self::Error>>;
 
     fn poll_ready(&self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        // log::error!("AD poll ready {:?}", std::thread::current().id());
         // idle ttimeout
         self.handle_idle_timeout(cx);
 
@@ -185,12 +184,12 @@ where
         // check readiness
         let res1 = self.service.poll_ready(cx).map_err(|err| {
             error!("Publish service readiness check failed: {:?}", err);
-            let _ = self.sink.close_with_error(&err);
+            let _ = self.sink.close_with_error(err.into());
             DispatcherError::Service
         })?;
         let res2 = self.ctl_service.poll_ready(cx).map_err(|err| {
             error!("Control service readiness check failed: {:?}", err);
-            let _ = self.sink.close_with_error(&err);
+            let _ = self.sink.close_with_error(err.into());
             DispatcherError::Service
         })?;
 
@@ -202,22 +201,21 @@ where
     }
 
     fn poll_shutdown(&self, cx: &mut Context<'_>, is_error: bool) -> Poll<()> {
-        if !self.shutdown.get() {
-            self.shutdown.set(true);
+        let mut shutdown = self.shutdown.borrow_mut();
+        if !shutdown.is_some() {
             let sink = self.sink.0.get_mut();
             sink.on_close.notify();
             sink.set_error(AmqpProtocolError::Disconnected);
-            let fut = self
-                .ctl_service
-                .call(ControlFrame::new_kind(ControlFrameKind::Closed(is_error)));
-            ntex::rt::spawn(async move {
-                let _ = fut.await;
-            });
+            *shutdown = Some(Box::pin(
+                self.ctl_service
+                    .call(ControlFrame::new_kind(ControlFrameKind::Closed(is_error))),
+            ));
         }
 
+        let res0 = shutdown.as_mut().expect("guard above").as_mut().poll(cx);
         let res1 = self.service.poll_shutdown(cx, is_error);
         let res2 = self.ctl_service.poll_shutdown(cx, is_error);
-        if res1.is_pending() || res2.is_pending() {
+        if res0.is_pending() || res1.is_pending() || res2.is_pending() {
             Poll::Pending
         } else {
             Poll::Ready(())
@@ -293,6 +291,11 @@ where
                         *self.ctl_fut.borrow_mut() =
                             Some((None, Box::pin(self.ctl_service.call(frame))));
                     }
+                    types::Action::RemoteClose(err) => {
+                        let frame = ControlFrame::new_kind(ControlFrameKind::ProtocolError(err));
+                        *self.ctl_fut.borrow_mut() =
+                            Some((Some(frame.clone()), Box::pin(self.ctl_service.call(frame))));
+                    }
                     types::Action::None => (),
                 };
 
@@ -312,9 +315,10 @@ where
                     Some((Some(frame.clone()), Box::pin(self.ctl_service.call(frame))));
                 Either::Right(Ready::Ok(()))
             }
-            DispatchItem::IoError(_) => {
-                let frame =
-                    ControlFrame::new_kind(ControlFrameKind::ProtocolError(AmqpProtocolError::Io));
+            DispatchItem::IoError(err) => {
+                let frame = ControlFrame::new_kind(ControlFrameKind::ProtocolError(
+                    AmqpProtocolError::Io(Rc::new(err)),
+                ));
                 *self.ctl_fut.borrow_mut() =
                     Some((Some(frame.clone()), Box::pin(self.ctl_service.call(frame))));
                 Either::Right(Ready::Ok(()))
@@ -338,8 +342,7 @@ pin_project_lite::pin_project! {
 impl<F, E> Future for ServiceResult<F, E>
 where
     F: Future<Output = Result<(), E>>,
-    E: fmt::Debug,
-    Error: From<E>,
+    E: Into<Error> + fmt::Debug,
 {
     type Output = Result<(), DispatcherError>;
 
@@ -351,7 +354,7 @@ where
             Poll::Ready(Ok(_)) => Poll::Ready(Ok(())),
             Poll::Ready(Err(e)) => {
                 log::trace!("Service error {:?}", e);
-                let _ = this.link.close_with_error(e);
+                let _ = this.link.close_with_error(e.into());
                 Poll::Ready(Ok::<_, DispatcherError>(()))
             }
         }

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -174,7 +174,6 @@ where
     type Future = Either<ServiceResult<Sr::Future, Sr::Error>, Ready<Self::Response, Self::Error>>;
 
     fn poll_ready(&self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        // log::error!("AD poll ready {:?}", std::thread::current().id());
         // idle ttimeout
         self.handle_idle_timeout(cx);
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use std::{convert::TryFrom, error, io};
+use std::{convert::TryFrom, error, io, rc::Rc};
 
 use ntex::util::{ByteString, Either};
 
@@ -56,7 +56,7 @@ pub enum AmqpProtocolError {
     BodyTooLarge,
     KeepAliveTimeout,
     Disconnected,
-    Io,
+    Io(Rc<io::Error>),
     #[display(fmt = "Unknown session: {:?}", _0)]
     UnknownSession(protocol::Frame),
     #[display(fmt = "Unknown link in session: {:?}", _0)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -4,7 +4,10 @@ use ntex::router::Path;
 use ntex::util::{ByteString, Either};
 
 use crate::codec::protocol::{Accepted, Attach, DeliveryState, Detach, Error, Flow, Rejected};
-use crate::{rcvlink::ReceiverLink, session::Session, sndlink::SenderLink, Handle, State};
+use crate::{
+    error::AmqpProtocolError, rcvlink::ReceiverLink, session::Session, sndlink::SenderLink, Handle,
+    State,
+};
 
 pub use crate::codec::protocol::Transfer;
 
@@ -24,6 +27,7 @@ pub(crate) enum Action {
     SessionEnded(Vec<Either<SenderLink, ReceiverLink>>),
     Flow(SenderLink, Flow),
     Transfer(ReceiverLink),
+    RemoteClose(AmqpProtocolError),
 }
 
 pub struct Link<S> {


### PR DESCRIPTION
* Send the close frame in close and close_with_error
* Allow the control service to handle remote_close
* Propagate IO errors
* Hold shutdown of dispatcher until control service has handled the close control message

**client improvement**
* Fix dispatcher trait bounds to allow different error types from Sr and Ctl
* Add client start with custom control service

Route handlers and router still needed in client start.