### PR TITLE
must respond with attach before detach when rejecting links

### DIFF
--- a/src/rcvlink.rs
+++ b/src/rcvlink.rs
@@ -247,6 +247,10 @@ impl ReceiverLinkInner {
         self.reader_task.wake();
     }
 
+    pub(crate) fn name(&self) -> &ByteString {
+        &self.name
+    }
+
     pub(crate) fn detached(&mut self) {
         // drop pending transfers
         self.queue.clear();


### PR DESCRIPTION
If a receiver link is closed (by control service err, publish service factory err, or explicit call to close on link) during remote opening, we need to send attach immediately followed by detach per figure 2.33 in [spec](http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-transport-v1.0-os.html#doc-idp315568).

Clients not expecting errant detach are hanging.