### PR TITLE
add support for described compound types in Variant

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ default = []
 frame-trace = []
 
 [dependencies]
-ntex = "2.10"
+ntex = { version = "2.10", default-features = false }
 ntex-amqp-codec = "0.9.8"
 
 bitflags = "2"
@@ -33,7 +33,7 @@ log = "0.4"
 pin-project-lite = "0.2"
 slab = "0.4"
 uuid = { version = "1", features = ["v4"] }
-derive_more = { version = "2", features = ["display", "from"] }
+derive_more = { version = "2", features = ["from"] }
 thiserror = "2"
 
 [dev-dependencies]

--- a/codec/Cargo.toml
+++ b/codec/Cargo.toml
@@ -13,8 +13,8 @@ ntex-codec = "0.6"
 byteorder = "1"
 fxhash = "0.2"
 chrono = { version = "0.4", default-features = false }
-derive_more = { version = "2", features = ["display", "from"] }
-ordered-float = "4.2"
+derive_more = { version = "2", features = ["from"] }
+ordered-float = "5"
 thiserror = "2"
 uuid = { version = "1", features = ["v4"] }
 
@@ -25,6 +25,9 @@ serde_derive = { version = "1", optional = true }
 serde_json   = { version = "1", optional = true }
 lazy_static  = { version = "1", optional = true }
 regex = { version = "1", optional = true }
+
+[dev-dependencies]
+test-case = "3"
 
 [features]
 default = []

--- a/codec/codegen/definitions.rs
+++ b/codec/codegen/definitions.rs
@@ -3,7 +3,7 @@
 use derive_more::From;
 
 use super::*;
-use crate::codec::{decode_format_code, decode_list_header};
+use crate::codec::{decode_format_code, ListHeader};
 
 #[derive(Clone, Debug, PartialEq, Eq, From)]
 pub enum Frame {
@@ -424,7 +424,7 @@ impl {{list.name}}Builder {
 #[allow(unused_mut)]
 fn decode_{{snake list.name}}_inner(input: &mut Bytes) -> Result<{{list.name}}, AmqpParseError> {
     let format = decode_format_code(input)?;
-    let header = decode_list_header(input, format)?;
+    let header = ListHeader::decode_with_format(input, format)?;
     let size = header.size as usize;
     decode_check_len!(input, size);
     {{#if list.fields}}
@@ -462,7 +462,7 @@ fn decode_{{snake list.name}}_inner(input: &mut Bytes) -> Result<{{list.name}}, 
     {{/if}}
     {{/each}}
     {{else}}
-    input.split_to(size);
+    input.advance(size);
     {{/if}}
 
     {{#if list.transfer}}

--- a/codec/src/codec/decode.rs
+++ b/codec/src/codec/decode.rs
@@ -2,37 +2,42 @@ use std::{char, collections, convert::TryFrom, hash::BuildHasher, hash::Hash};
 
 use byteorder::{BigEndian, ByteOrder};
 use chrono::{DateTime, TimeZone, Utc};
-use ntex_bytes::{ByteString, Bytes};
+use ntex_bytes::{Buf, ByteString, Bytes};
 use ordered_float::OrderedFloat;
 use uuid::Uuid;
 
-use crate::codec::{self, ArrayDecode, Decode, DecodeFormatted};
+use crate::codec::{
+    self, decode_format_code, ArrayHeader, Decode, DecodeFormatted, ListHeader, MapHeader,
+};
 use crate::error::AmqpParseError;
 use crate::framing::{self, AmqpFrame, SaslFrame, HEADER_LEN};
-use crate::protocol::{self, CompoundHeader};
+use crate::protocol;
 use crate::types::{
-    Array, Descriptor, List, Multiple, Str, Symbol, Variant, VariantMap, VecStringMap, VecSymbolMap,
+    Array, Constructor, DescribedCompound, Descriptor, List, Multiple, Str, Symbol, Variant,
+    VariantMap, VecStringMap, VecSymbolMap,
 };
 use crate::HashMap;
 
 macro_rules! be_read {
     ($input:ident, $fn:ident, $size:expr) => {{
         decode_check_len!($input, $size);
-        Ok(BigEndian::$fn(&$input.split_to($size)))
+        let result = BigEndian::$fn(&$input);
+        $input.advance($size);
+        Ok(result)
     }};
 }
 
 fn read_u8(input: &mut Bytes) -> Result<u8, AmqpParseError> {
     decode_check_len!(input, 1);
     let code = input[0];
-    input.split_to(1);
+    input.advance(1);
     Ok(code)
 }
 
 fn read_i8(input: &mut Bytes) -> Result<i8, AmqpParseError> {
     decode_check_len!(input, 1);
     let code = input[0] as i8;
-    input.split_to(1);
+    input.advance(1);
     Ok(code)
 }
 
@@ -213,7 +218,7 @@ impl DecodeFormatted for ByteString {
 
 impl DecodeFormatted for Str {
     fn decode_with_format(input: &mut Bytes, fmt: u8) -> Result<Self, AmqpParseError> {
-        Ok(Str::ByteStr(ByteString::decode_with_format(input, fmt)?))
+        Ok(Str::from(ByteString::decode_with_format(input, fmt)?))
     }
 }
 
@@ -222,13 +227,13 @@ impl DecodeFormatted for Symbol {
         match fmt {
             codec::FORMATCODE_SYMBOL8 => {
                 let bytes = read_bytes_u8(input)?;
-                Ok(Symbol(Str::ByteStr(
+                Ok(Symbol(Str::from(
                     ByteString::try_from(bytes).map_err(|_| AmqpParseError::Utf8Error)?,
                 )))
             }
             codec::FORMATCODE_SYMBOL32 => {
                 let bytes = read_bytes_u32(input)?;
-                Ok(Symbol(Str::ByteStr(
+                Ok(Symbol(Str::from(
                     ByteString::try_from(bytes).map_err(|_| AmqpParseError::Utf8Error)?,
                 )))
             }
@@ -237,19 +242,11 @@ impl DecodeFormatted for Symbol {
     }
 }
 
-impl ArrayDecode for Symbol {
-    fn array_decode(input: &mut Bytes) -> Result<Self, AmqpParseError> {
-        let bytes =
-            ByteString::try_from(read_bytes_u32(input)?).map_err(|_| AmqpParseError::Utf8Error)?;
-        Ok(Symbol(Str::ByteStr(bytes)))
-    }
-}
-
 impl<K: Decode + Eq + Hash, V: Decode, S: BuildHasher + Default> DecodeFormatted
     for collections::HashMap<K, V, S>
 {
     fn decode_with_format(input: &mut Bytes, fmt: u8) -> Result<Self, AmqpParseError> {
-        let header = decode_map_header(input, fmt)?;
+        let header = MapHeader::decode_with_format(input, fmt)?;
         decode_check_len!(input, header.size as usize);
         let mut map_input = input.split_to(header.size as usize);
         let count = header.count / 2;
@@ -267,10 +264,8 @@ impl<K: Decode + Eq + Hash, V: Decode, S: BuildHasher + Default> DecodeFormatted
 
 impl<T: DecodeFormatted> DecodeFormatted for Vec<T> {
     fn decode_with_format(input: &mut Bytes, fmt: u8) -> Result<Self, AmqpParseError> {
-        let header = decode_array_header(input, fmt)?;
-        decode_check_len!(input, 1);
-        let item_fmt = input[0]; // todo: support descriptor
-        input.split_to(1);
+        let header = ArrayHeader::decode_with_format(input, fmt)?;
+        let item_fmt = decode_format_code(input)?; // todo: mg: support descriptor
         let mut result: Vec<T> = Vec::with_capacity(header.count as usize);
         for _ in 0..header.count {
             let decoded = T::decode_with_format(input, item_fmt)?;
@@ -282,7 +277,7 @@ impl<T: DecodeFormatted> DecodeFormatted for Vec<T> {
 
 impl DecodeFormatted for VecSymbolMap {
     fn decode_with_format(input: &mut Bytes, fmt: u8) -> Result<Self, AmqpParseError> {
-        let header = decode_map_header(input, fmt)?;
+        let header = MapHeader::decode_with_format(input, fmt)?;
         decode_check_len!(input, header.size as usize);
         let mut map_input = input.split_to(header.size as usize);
         let count = header.count / 2;
@@ -299,7 +294,7 @@ impl DecodeFormatted for VecSymbolMap {
 
 impl DecodeFormatted for VecStringMap {
     fn decode_with_format(input: &mut Bytes, fmt: u8) -> Result<Self, AmqpParseError> {
-        let header = decode_map_header(input, fmt)?;
+        let header = MapHeader::decode_with_format(input, fmt)?;
         decode_check_len!(input, header.size as usize);
         let mut map_input = input.split_to(header.size as usize);
         let count = header.count / 2;
@@ -314,7 +309,7 @@ impl DecodeFormatted for VecStringMap {
     }
 }
 
-impl<T: ArrayDecode + DecodeFormatted> DecodeFormatted for Multiple<T> {
+impl<T: DecodeFormatted> DecodeFormatted for Multiple<T> {
     fn decode_with_format(input: &mut Bytes, fmt: u8) -> Result<Self, AmqpParseError> {
         match fmt {
             codec::FORMATCODE_ARRAY8 | codec::FORMATCODE_ARRAY32 => {
@@ -331,7 +326,7 @@ impl<T: ArrayDecode + DecodeFormatted> DecodeFormatted for Multiple<T> {
 
 impl DecodeFormatted for List {
     fn decode_with_format(input: &mut Bytes, fmt: u8) -> Result<Self, AmqpParseError> {
-        let header = decode_list_header(input, fmt)?;
+        let header = ListHeader::decode_with_format(input, fmt)?;
         let mut result: Vec<Variant> = Vec::with_capacity(header.count as usize);
         for _ in 0..header.count {
             let decoded = Variant::decode(input)?;
@@ -368,9 +363,9 @@ impl DecodeFormatted for Variant {
             codec::FORMATCODE_DOUBLE => {
                 f64::decode_with_format(input, fmt).map(|o| Variant::Double(OrderedFloat(o)))
             }
-            // codec::FORMATCODE_DECIMAL32 => x::decode_with_format(input, fmt).map(|(i, o)| (i, Variant::Decimal(o))),
-            // codec::FORMATCODE_DECIMAL64 => x::decode_with_format(input, fmt).map(|(i, o)| (i, Variant::Decimal(o))),
-            // codec::FORMATCODE_DECIMAL128 => x::decode_with_format(input, fmt).map(|(i, o)| (i, Variant::Decimal(o))),
+            codec::FORMATCODE_DECIMAL32 => read_fixed_bytes(input).map(Variant::Decimal32),
+            codec::FORMATCODE_DECIMAL64 => read_fixed_bytes(input).map(Variant::Decimal64),
+            codec::FORMATCODE_DECIMAL128 => read_fixed_bytes(input).map(Variant::Decimal128),
             codec::FORMATCODE_CHAR => char::decode_with_format(input, fmt).map(Variant::Char),
             codec::FORMATCODE_TIMESTAMP => {
                 DateTime::<Utc>::decode_with_format(input, fmt).map(Variant::Timestamp)
@@ -398,8 +393,45 @@ impl DecodeFormatted for Variant {
             }
             codec::FORMATCODE_DESCRIBED => {
                 let descriptor = Descriptor::decode(input)?;
-                let value = Variant::decode(input)?;
-                Ok(Variant::Described((descriptor, Box::new(value))))
+                let format_code = {
+                    decode_check_len!(input, 1);
+                    let code = input[0];
+                    Ok(code)
+                }?;
+                match format_code {
+                    codec::FORMATCODE_LIST0 => {
+                        input.advance(1); // advance past format code
+                        Ok(Variant::DescribedCompound(DescribedCompound::new(
+                            descriptor,
+                            Bytes::from_static(&[codec::FORMATCODE_LIST0]),
+                        )))
+                    }
+                    codec::FORMATCODE_LIST8 | codec::FORMATCODE_MAP8 | codec::FORMATCODE_ARRAY8 => {
+                        decode_check_len!(input, 2);
+                        let size = input[1] as usize;
+                        decode_check_len!(input, 2 + size);
+                        let data = input.split_to(2 + size);
+                        Ok(Variant::DescribedCompound(DescribedCompound::new(
+                            descriptor, data,
+                        )))
+                    }
+                    codec::FORMATCODE_LIST32
+                    | codec::FORMATCODE_MAP32
+                    | codec::FORMATCODE_ARRAY32 => {
+                        decode_check_len!(input, 5);
+                        let size = u32::from_be_bytes(input[1..5].try_into().unwrap()) as usize;
+                        decode_check_len!(input, 5 + size);
+                        let data = input.split_to(5 + size);
+                        Ok(Variant::DescribedCompound(DescribedCompound::new(
+                            descriptor, data,
+                        )))
+                    }
+                    _ => {
+                        input.advance(1); // advance past format code
+                        let value = Variant::decode_with_format(input, format_code)?;
+                        Ok(Variant::Described((descriptor, Box::new(value))))
+                    }
+                }
             }
             _ => Err(AmqpParseError::InvalidFormatCode(fmt)),
         }
@@ -433,6 +465,22 @@ impl DecodeFormatted for Descriptor {
     }
 }
 
+impl DecodeFormatted for Constructor {
+    fn decode_with_format(input: &mut Bytes, fmt: u8) -> Result<Self, AmqpParseError> {
+        match fmt {
+            codec::FORMATCODE_DESCRIBED => {
+                let descriptor = Descriptor::decode(input)?;
+                let format_code = codec::decode_format_code(input)?;
+                Ok(Constructor::Described {
+                    descriptor,
+                    format_code,
+                })
+            }
+            _ => Ok(Constructor::FormatCode(fmt)),
+        }
+    }
+}
+
 impl Decode for AmqpFrame {
     fn decode(input: &mut Bytes) -> Result<Self, AmqpParseError> {
         let channel_id = decode_frame_header(input, framing::FRAME_TYPE_AMQP)?;
@@ -446,6 +494,49 @@ impl Decode for SaslFrame {
         let _ = decode_frame_header(input, framing::FRAME_TYPE_SASL)?;
         let frame = protocol::SaslFrameBody::decode(input)?;
         Ok(SaslFrame { body: frame })
+    }
+}
+
+impl DecodeFormatted for ListHeader {
+    fn decode_with_format(input: &mut Bytes, fmt: u8) -> Result<Self, AmqpParseError> {
+        match fmt {
+            codec::FORMATCODE_LIST0 => Ok(ListHeader { count: 0, size: 0 }),
+            codec::FORMATCODE_LIST8 => {
+                decode_compound8(input).map(|(size, count)| ListHeader { count, size })
+            }
+            codec::FORMATCODE_LIST32 => {
+                decode_compound32(input).map(|(size, count)| ListHeader { count, size })
+            }
+            _ => Err(AmqpParseError::InvalidFormatCode(fmt)),
+        }
+    }
+}
+
+impl DecodeFormatted for MapHeader {
+    fn decode_with_format(input: &mut Bytes, fmt: u8) -> Result<Self, AmqpParseError> {
+        match fmt {
+            codec::FORMATCODE_MAP8 => {
+                decode_compound8(input).map(|(size, count)| MapHeader { count, size })
+            }
+            codec::FORMATCODE_MAP32 => {
+                decode_compound32(input).map(|(size, count)| MapHeader { count, size })
+            }
+            _ => Err(AmqpParseError::InvalidFormatCode(fmt)),
+        }
+    }
+}
+
+impl DecodeFormatted for ArrayHeader {
+    fn decode_with_format(input: &mut Bytes, fmt: u8) -> Result<Self, AmqpParseError> {
+        match fmt {
+            codec::FORMATCODE_ARRAY8 => {
+                decode_compound8(input).map(|(size, count)| ArrayHeader { count, size })
+            }
+            codec::FORMATCODE_ARRAY32 => {
+                decode_compound32(input).map(|(size, count)| ArrayHeader { count, size })
+            }
+            _ => Err(AmqpParseError::InvalidFormatCode(fmt)),
+        }
     }
 }
 
@@ -465,61 +556,24 @@ fn decode_frame_header(input: &mut Bytes, expected_frame_type: u8) -> Result<u16
     // skipping remaining two header bytes and ext header
     let ext_header_len = doff - HEADER_LEN + 4;
     decode_check_len!(input, ext_header_len);
-    input.split_to(ext_header_len);
+    input.advance(ext_header_len);
     Ok(channel_id)
 }
 
-pub(crate) fn decode_array_header(
-    input: &mut Bytes,
-    fmt: u8,
-) -> Result<CompoundHeader, AmqpParseError> {
-    match fmt {
-        codec::FORMATCODE_ARRAY8 => decode_compound8(input),
-        codec::FORMATCODE_ARRAY32 => decode_compound32(input),
-        _ => Err(AmqpParseError::InvalidFormatCode(fmt)),
-    }
-}
-
-pub(crate) fn decode_list_header(
-    input: &mut Bytes,
-    fmt: u8,
-) -> Result<CompoundHeader, AmqpParseError> {
-    match fmt {
-        codec::FORMATCODE_LIST0 => Ok(CompoundHeader::empty()),
-        codec::FORMATCODE_LIST8 => decode_compound8(input),
-        codec::FORMATCODE_LIST32 => decode_compound32(input),
-        _ => Err(AmqpParseError::InvalidFormatCode(fmt)),
-    }
-}
-
-pub(crate) fn decode_map_header(
-    input: &mut Bytes,
-    fmt: u8,
-) -> Result<CompoundHeader, AmqpParseError> {
-    match fmt {
-        codec::FORMATCODE_MAP8 => decode_compound8(input),
-        codec::FORMATCODE_MAP32 => decode_compound32(input),
-        _ => Err(AmqpParseError::InvalidFormatCode(fmt)),
-    }
-}
-
-fn decode_compound8(input: &mut Bytes) -> Result<CompoundHeader, AmqpParseError> {
+fn decode_compound8(input: &mut Bytes) -> Result<(u32, u32), AmqpParseError> {
     decode_check_len!(input, 2);
     let size = input[0] - 1; // -1 for 1 byte count
     let count = input[1];
-    input.split_to(2);
-    Ok(CompoundHeader {
-        size: u32::from(size),
-        count: u32::from(count),
-    })
+    input.advance(2);
+    Ok((u32::from(size), u32::from(count)))
 }
 
-fn decode_compound32(input: &mut Bytes) -> Result<CompoundHeader, AmqpParseError> {
+fn decode_compound32(input: &mut Bytes) -> Result<(u32, u32), AmqpParseError> {
     decode_check_len!(input, 8);
     let size = BigEndian::read_u32(input) - 4; // -4 for 4 byte count
     let count = BigEndian::read_u32(&input[4..]);
-    input.split_to(8);
-    Ok(CompoundHeader { size, count })
+    input.advance(8);
+    Ok((size, count))
 }
 
 fn datetime_from_millis(millis: i64) -> Result<DateTime<Utc>, AmqpParseError> {
@@ -540,10 +594,19 @@ fn datetime_from_millis(millis: i64) -> Result<DateTime<Utc>, AmqpParseError> {
     }
 }
 
+fn read_fixed_bytes<const N: usize>(input: &mut Bytes) -> Result<[u8; N], AmqpParseError> {
+    decode_check_len!(input, N);
+    let mut data = [0u8; N];
+    data.copy_from_slice(&input[..N]);
+    input.advance(N);
+    Ok(data)
+}
+
 #[cfg(test)]
 mod tests {
     use chrono::TimeDelta;
     use ntex_bytes::{BufMut, BytesMut};
+    use test_case::test_case;
 
     use super::*;
     use crate::codec::{Decode, Encode};
@@ -778,6 +841,97 @@ mod tests {
             Variant::Timestamp(expected),
             unwrap_value(Variant::decode(&mut b1.freeze()))
         );
+    }
+
+    #[test_case(
+        b"\x00\xa3\x07foo:bar\xc0\x03\x01\x50\x03",
+        Descriptor::Symbol("foo:bar".into()),
+        List(vec![Variant::Ubyte(3)]);
+        "described 'foo:bar', list8 w/one u8 field with value 3")]
+    #[test_case(
+        b"\x00\x80\x00\x00\x01\x37\x00\x00\x03\xe9\x45",
+        Descriptor::Ulong((311 << 32) + 1001), List(vec![]); "described 311:1001, list0")]
+    #[test_case(
+        b"\x00\x80\x00\x01\xd4\xc0\x00\x03\x82\x70\xd0\x00\x00\x00\x0c\x00\x00\x00\x03\x53\x6f\xa1\x03abc\x42",
+        Descriptor::Ulong((120_000 << 32) + 230_000),
+        List(vec![Variant::Ulong(111), Variant::String("abc".into()), Variant::Boolean(false)]);
+        "described 120000:230000, list32 w/3 fields: smallulong: 111, string8: 'abc', booleanfalse")]
+    fn decode_described_list(
+        input: &'static [u8],
+        expected_descriptor: Descriptor,
+        expected_list: List,
+    ) {
+        let mut buf = Bytes::from(input);
+        let variant = Variant::decode(&mut buf).unwrap();
+        assert!(buf.is_empty(), "Expected no remaining bytes after decoding");
+        let dc = match variant {
+            Variant::DescribedCompound(dc) => dc,
+            _ => panic!("Expected a DescribedCompound variant"),
+        };
+        assert_eq!(dc.descriptor(), &expected_descriptor);
+        println!("{:02x?}", dc.data.as_ref());
+        let decoded_list: List = dc.decode().expect("Failed to decode List");
+        assert_eq!(decoded_list, expected_list);
+    }
+
+    #[test_case(
+        b"\x00\xa3\x05a:b:c\xc1\x08\x04\x50\x03\x41\x50\xc8\x56\x00",
+        Descriptor::Symbol("a:b:c".into()),
+        vec![(Variant::Ubyte(3), Variant::Boolean(true)), (Variant::Ubyte(200), Variant::Boolean(false))];
+        "described 'a:b:c', map8 with 2 pairs: (ubyte(3), true), (ubyte(200), false)")]
+    #[test_case(
+        b"\x00\x80\x00\x01\xd4\xc0\x00\x03\x82\x70\xd1\x00\x00\x00\x0a\x00\x00\x00\x02\x73\x00\x00\x00z\x40",
+        Descriptor::Ulong((120_000 << 32) + 230_000),
+        vec![(Variant::Char('z'), Variant::Null)];
+        "described 120000:230000, map32 with 1 pair: char: 'z', null")]
+    fn decode_described_map(
+        input: &'static [u8],
+        expected_descriptor: Descriptor,
+        expected_map: Vec<(Variant, Variant)>,
+    ) {
+        let mut buf = Bytes::from(input);
+        let variant = Variant::decode(&mut buf).unwrap();
+        assert!(buf.is_empty(), "Expected no remaining bytes after decoding");
+        let dc = match variant {
+            Variant::DescribedCompound(dc) => dc,
+            _ => panic!("Expected a DescribedCompound variant"),
+        };
+        assert_eq!(dc.descriptor(), &expected_descriptor);
+        println!("{:02x?}", dc.data.as_ref());
+        let decoded_map: HashMap<Variant, Variant> = dc.decode().expect("Failed to decode List");
+        let expected_map: HashMap<Variant, Variant> = expected_map.into_iter().collect();
+        assert_eq!(decoded_map, expected_map);
+    }
+
+    #[test_case(
+        b"\x00\xa3\x07foo:bar\xe0\x05\x03\x50\x01\x02\x03",
+        Descriptor::Symbol("foo:bar".into()),
+        Constructor::FormatCode(codec::FORMATCODE_UBYTE),
+        vec![Variant::Ubyte(1), Variant::Ubyte(2), Variant::Ubyte(3)];
+        "described 'foo:bar', array8 w/3 u8 elements: 1, 2, 3")]
+    fn decode_described_array(
+        input: &'static [u8],
+        expected_descriptor: Descriptor,
+        expected_el_ctor: Constructor,
+        expected_array: Vec<Variant>,
+    ) {
+        // todo: mg: array decoding: add check that all bytes are read out according to size when done decoding array elements /
+        // list fields / map key-value pairs according to count
+        let mut buf = Bytes::from(input);
+        let variant = Variant::decode(&mut buf).unwrap();
+        assert!(buf.is_empty(), "Expected no remaining bytes after decoding");
+        let dc = match variant {
+            Variant::DescribedCompound(dc) => dc,
+            _ => panic!("Expected a DescribedCompound variant"),
+        };
+        assert_eq!(dc.descriptor(), &expected_descriptor);
+        println!("{:02x?}", dc.data.as_ref());
+        let decoded_array: Array = dc.decode().expect("Failed to decode Array");
+        assert_eq!(decoded_array.element_constructor(), &expected_el_ctor);
+        let array_items: Vec<Variant> = decoded_array
+            .decode()
+            .expect("Failed to decode Array items using Variant type");
+        assert_eq!(array_items, expected_array);
     }
 
     #[test]

--- a/codec/src/codec/encode.rs
+++ b/codec/src/codec/encode.rs
@@ -7,7 +7,8 @@ use uuid::Uuid;
 use crate::codec::{self, ArrayEncode, Encode};
 use crate::framing::{self, AmqpFrame, SaslFrame};
 use crate::types::{
-    Descriptor, List, Multiple, StaticSymbol, Str, Symbol, Variant, VecStringMap, VecSymbolMap,
+    Constructor, Descriptor, List, Multiple, StaticSymbol, Str, Symbol, Variant, VecStringMap,
+    VecSymbolMap,
 };
 
 fn encode_null(buf: &mut BytesMut) {
@@ -21,7 +22,7 @@ impl<T: FixedEncode + ArrayEncode> Encode for T {
         self.array_encoded_size() + 1
     }
     fn encode(&self, buf: &mut BytesMut) {
-        buf.put_u8(T::ARRAY_FORMAT_CODE);
+        T::ARRAY_CONSTRUCTOR.encode(buf);
         self.array_encode(buf);
     }
 }
@@ -39,7 +40,7 @@ impl Encode for bool {
     }
 }
 impl ArrayEncode for bool {
-    const ARRAY_FORMAT_CODE: u8 = codec::FORMATCODE_BOOLEAN;
+    const ARRAY_CONSTRUCTOR: Constructor = Constructor::FormatCode(codec::FORMATCODE_BOOLEAN);
     fn array_encoded_size(&self) -> usize {
         1
     }
@@ -50,7 +51,7 @@ impl ArrayEncode for bool {
 
 impl FixedEncode for u8 {}
 impl ArrayEncode for u8 {
-    const ARRAY_FORMAT_CODE: u8 = codec::FORMATCODE_UBYTE;
+    const ARRAY_CONSTRUCTOR: Constructor = Constructor::FormatCode(codec::FORMATCODE_UBYTE);
     fn array_encoded_size(&self) -> usize {
         1
     }
@@ -61,7 +62,7 @@ impl ArrayEncode for u8 {
 
 impl FixedEncode for u16 {}
 impl ArrayEncode for u16 {
-    const ARRAY_FORMAT_CODE: u8 = codec::FORMATCODE_USHORT;
+    const ARRAY_CONSTRUCTOR: Constructor = Constructor::FormatCode(codec::FORMATCODE_USHORT);
     fn array_encoded_size(&self) -> usize {
         2
     }
@@ -93,7 +94,7 @@ impl Encode for u32 {
     }
 }
 impl ArrayEncode for u32 {
-    const ARRAY_FORMAT_CODE: u8 = codec::FORMATCODE_UINT;
+    const ARRAY_CONSTRUCTOR: Constructor = Constructor::FormatCode(codec::FORMATCODE_UINT);
     fn array_encoded_size(&self) -> usize {
         4
     }
@@ -127,7 +128,7 @@ impl Encode for u64 {
 }
 
 impl ArrayEncode for u64 {
-    const ARRAY_FORMAT_CODE: u8 = codec::FORMATCODE_ULONG;
+    const ARRAY_CONSTRUCTOR: Constructor = Constructor::FormatCode(codec::FORMATCODE_ULONG);
     fn array_encoded_size(&self) -> usize {
         8
     }
@@ -139,7 +140,7 @@ impl ArrayEncode for u64 {
 impl FixedEncode for i8 {}
 
 impl ArrayEncode for i8 {
-    const ARRAY_FORMAT_CODE: u8 = codec::FORMATCODE_BYTE;
+    const ARRAY_CONSTRUCTOR: Constructor = Constructor::FormatCode(codec::FORMATCODE_BYTE);
     fn array_encoded_size(&self) -> usize {
         1
     }
@@ -151,7 +152,7 @@ impl ArrayEncode for i8 {
 impl FixedEncode for i16 {}
 
 impl ArrayEncode for i16 {
-    const ARRAY_FORMAT_CODE: u8 = codec::FORMATCODE_SHORT;
+    const ARRAY_CONSTRUCTOR: Constructor = Constructor::FormatCode(codec::FORMATCODE_SHORT);
     fn array_encoded_size(&self) -> usize {
         2
     }
@@ -181,7 +182,7 @@ impl Encode for i32 {
 }
 
 impl ArrayEncode for i32 {
-    const ARRAY_FORMAT_CODE: u8 = codec::FORMATCODE_INT;
+    const ARRAY_CONSTRUCTOR: Constructor = Constructor::FormatCode(codec::FORMATCODE_INT);
 
     fn array_encoded_size(&self) -> usize {
         4
@@ -213,7 +214,7 @@ impl Encode for i64 {
 }
 
 impl ArrayEncode for i64 {
-    const ARRAY_FORMAT_CODE: u8 = codec::FORMATCODE_LONG;
+    const ARRAY_CONSTRUCTOR: Constructor = Constructor::FormatCode(codec::FORMATCODE_LONG);
     fn array_encoded_size(&self) -> usize {
         8
     }
@@ -225,7 +226,7 @@ impl ArrayEncode for i64 {
 impl FixedEncode for f32 {}
 
 impl ArrayEncode for f32 {
-    const ARRAY_FORMAT_CODE: u8 = codec::FORMATCODE_FLOAT;
+    const ARRAY_CONSTRUCTOR: Constructor = Constructor::FormatCode(codec::FORMATCODE_FLOAT);
 
     fn array_encoded_size(&self) -> usize {
         4
@@ -239,7 +240,7 @@ impl ArrayEncode for f32 {
 impl FixedEncode for f64 {}
 
 impl ArrayEncode for f64 {
-    const ARRAY_FORMAT_CODE: u8 = codec::FORMATCODE_DOUBLE;
+    const ARRAY_CONSTRUCTOR: Constructor = Constructor::FormatCode(codec::FORMATCODE_DOUBLE);
     fn array_encoded_size(&self) -> usize {
         8
     }
@@ -251,7 +252,7 @@ impl ArrayEncode for f64 {
 impl FixedEncode for char {}
 
 impl ArrayEncode for char {
-    const ARRAY_FORMAT_CODE: u8 = codec::FORMATCODE_CHAR;
+    const ARRAY_CONSTRUCTOR: Constructor = Constructor::FormatCode(codec::FORMATCODE_CHAR);
     fn array_encoded_size(&self) -> usize {
         4
     }
@@ -263,7 +264,7 @@ impl ArrayEncode for char {
 impl FixedEncode for DateTime<Utc> {}
 
 impl ArrayEncode for DateTime<Utc> {
-    const ARRAY_FORMAT_CODE: u8 = codec::FORMATCODE_TIMESTAMP;
+    const ARRAY_CONSTRUCTOR: Constructor = Constructor::FormatCode(codec::FORMATCODE_TIMESTAMP);
     fn array_encoded_size(&self) -> usize {
         8
     }
@@ -276,7 +277,7 @@ impl ArrayEncode for DateTime<Utc> {
 impl FixedEncode for Uuid {}
 
 impl ArrayEncode for Uuid {
-    const ARRAY_FORMAT_CODE: u8 = codec::FORMATCODE_UUID;
+    const ARRAY_CONSTRUCTOR: Constructor = Constructor::FormatCode(codec::FORMATCODE_UUID);
     fn array_encoded_size(&self) -> usize {
         16
     }
@@ -306,7 +307,7 @@ impl Encode for Bytes {
 }
 
 impl ArrayEncode for Bytes {
-    const ARRAY_FORMAT_CODE: u8 = codec::FORMATCODE_BINARY32;
+    const ARRAY_CONSTRUCTOR: Constructor = Constructor::FormatCode(codec::FORMATCODE_BINARY32);
     fn array_encoded_size(&self) -> usize {
         4 + self.len()
     }
@@ -336,7 +337,7 @@ impl Encode for ByteString {
     }
 }
 impl ArrayEncode for ByteString {
-    const ARRAY_FORMAT_CODE: u8 = codec::FORMATCODE_STRING32;
+    const ARRAY_CONSTRUCTOR: Constructor = Constructor::FormatCode(codec::FORMATCODE_STRING32);
     fn array_encoded_size(&self) -> usize {
         4 + self.len()
     }
@@ -367,7 +368,7 @@ impl Encode for str {
 }
 
 impl ArrayEncode for str {
-    const ARRAY_FORMAT_CODE: u8 = codec::FORMATCODE_STRING32;
+    const ARRAY_CONSTRUCTOR: Constructor = Constructor::FormatCode(codec::FORMATCODE_STRING32);
     fn array_encoded_size(&self) -> usize {
         4 + self.len()
     }
@@ -418,7 +419,7 @@ impl Encode for Symbol {
 }
 
 impl ArrayEncode for Symbol {
-    const ARRAY_FORMAT_CODE: u8 = codec::FORMATCODE_SYMBOL32;
+    const ARRAY_CONSTRUCTOR: Constructor = Constructor::FormatCode(codec::FORMATCODE_SYMBOL32);
     fn array_encoded_size(&self) -> usize {
         4 + self.len()
     }
@@ -484,7 +485,7 @@ impl<K: Eq + Hash + Encode, V: Encode, S: BuildHasher> Encode for HashMap<K, V, 
 }
 
 impl<K: Eq + Hash + Encode, V: Encode> ArrayEncode for HashMap<K, V> {
-    const ARRAY_FORMAT_CODE: u8 = codec::FORMATCODE_MAP32;
+    const ARRAY_CONSTRUCTOR: Constructor = Constructor::FormatCode(codec::FORMATCODE_MAP32);
     fn array_encoded_size(&self) -> usize {
         8 + map_encoded_size(self)
     }
@@ -600,7 +601,7 @@ impl<T: ArrayEncode> Encode for Vec<T> {
             buf.put_u8((size + 2) as u8); // +1 for 1 byte count and 1 byte item ctor that follow
             buf.put_u8(self.len() as u8);
         }
-        buf.put_u8(T::ARRAY_FORMAT_CODE);
+        T::ARRAY_CONSTRUCTOR.encode(buf);
         for i in self {
             i.array_encode(buf);
         }
@@ -676,17 +677,20 @@ impl Encode for Variant {
             Variant::Long(l) => l.encoded_size(),
             Variant::Float(f) => f.encoded_size(),
             Variant::Double(d) => d.encoded_size(),
+            Variant::Decimal32(_) => 1 + 4,
+            Variant::Decimal64(_) => 1 + 8,
+            Variant::Decimal128(_) => 1 + 16,
             Variant::Char(c) => c.encoded_size(),
             Variant::Timestamp(ref t) => t.encoded_size(),
             Variant::Uuid(ref u) => u.encoded_size(),
             Variant::Binary(ref b) => b.encoded_size(),
             Variant::String(ref s) => s.encoded_size(),
             Variant::Symbol(ref s) => s.encoded_size(),
-            Variant::StaticSymbol(ref s) => s.encoded_size(),
             Variant::List(ref l) => l.encoded_size(),
             Variant::Array(ref a) => a.encoded_size(),
             Variant::Map(ref m) => m.map.encoded_size(),
             Variant::Described(ref dv) => dv.0.encoded_size() + dv.1.encoded_size(),
+            Variant::DescribedCompound(ref described) => described.encoded_size(),
         }
     }
 
@@ -705,13 +709,24 @@ impl Encode for Variant {
             Variant::Long(l) => l.encode(buf),
             Variant::Float(f) => f.encode(buf),
             Variant::Double(d) => d.encode(buf),
+            Variant::Decimal32(ref data) => {
+                buf.put_u8(codec::FORMATCODE_DECIMAL32);
+                buf.extend_from_slice(data.as_ref());
+            }
+            Variant::Decimal64(ref data) => {
+                buf.put_u8(codec::FORMATCODE_DECIMAL64);
+                buf.extend_from_slice(data.as_ref());
+            }
+            Variant::Decimal128(ref data) => {
+                buf.put_u8(codec::FORMATCODE_DECIMAL128);
+                buf.extend_from_slice(data.as_ref());
+            }
             Variant::Char(c) => c.encode(buf),
             Variant::Timestamp(ref t) => t.encode(buf),
             Variant::Uuid(ref u) => u.encode(buf),
             Variant::Binary(ref b) => b.encode(buf),
             Variant::String(ref s) => s.encode(buf),
             Variant::Symbol(ref s) => s.encode(buf),
-            Variant::StaticSymbol(ref s) => s.encode(buf),
             Variant::List(ref l) => l.encode(buf),
             Variant::Map(ref m) => m.map.encode(buf),
             Variant::Array(ref a) => a.encode(buf),
@@ -719,6 +734,7 @@ impl Encode for Variant {
                 dv.0.encode(buf);
                 dv.1.encode(buf);
             }
+            Variant::DescribedCompound(ref described) => described.encode(buf),
         }
     }
 }
@@ -738,9 +754,10 @@ impl<T: Encode> Encode for Option<T> {
 
 impl Encode for Descriptor {
     fn encoded_size(&self) -> usize {
-        match *self {
-            Descriptor::Ulong(v) => 1 + v.encoded_size(),
-            Descriptor::Symbol(ref v) => 1 + v.encoded_size(),
+        // 1 for described type's format code (0x00) + size of the descriptor value itself
+        1 + match *self {
+            Descriptor::Ulong(v) => v.encoded_size(),
+            Descriptor::Symbol(ref v) => v.encoded_size(),
         }
     }
 
@@ -749,6 +766,31 @@ impl Encode for Descriptor {
         match *self {
             Descriptor::Ulong(v) => v.encode(buf),
             Descriptor::Symbol(ref v) => v.encode(buf),
+        }
+    }
+}
+
+impl Encode for Constructor {
+    fn encoded_size(&self) -> usize {
+        match self {
+            Constructor::FormatCode(_) => 1,
+            Constructor::Described {
+                descriptor,
+                format_code: _,
+            } => 1 + descriptor.encoded_size(),
+        }
+    }
+
+    fn encode(&self, buf: &mut BytesMut) {
+        match self {
+            Constructor::FormatCode(format_code) => buf.put_u8(*format_code),
+            Constructor::Described {
+                descriptor,
+                format_code,
+            } => {
+                descriptor.encode(buf);
+                buf.put_u8(*format_code);
+            }
         }
     }
 }

--- a/codec/src/codec/encode.rs
+++ b/codec/src/codec/encode.rs
@@ -183,11 +183,9 @@ impl Encode for i32 {
 
 impl ArrayEncode for i32 {
     const ARRAY_CONSTRUCTOR: Constructor = Constructor::FormatCode(codec::FORMATCODE_INT);
-
     fn array_encoded_size(&self) -> usize {
         4
     }
-
     fn array_encode(&self, buf: &mut BytesMut) {
         buf.put_i32(*self);
     }
@@ -613,7 +611,6 @@ impl<T: Encode + ArrayEncode> Encode for Multiple<T> {
     fn encoded_size(&self) -> usize {
         let count = self.len();
         match count {
-            0 => 1, // only NULL format code
             1 => self.0[0].encoded_size(),
             _ => self.0.encoded_size(),
         }
@@ -622,7 +619,6 @@ impl<T: Encode + ArrayEncode> Encode for Multiple<T> {
     fn encode(&self, buf: &mut BytesMut) {
         let count = self.0.len();
         match count {
-            0 => encode_null(buf),
             1 => self.0[0].encode(buf),
             _ => self.0.encode(buf),
         }

--- a/codec/src/codec/mod.rs
+++ b/codec/src/codec/mod.rs
@@ -1,6 +1,6 @@
-use ntex_bytes::{Bytes, BytesMut};
+use ntex_bytes::{Buf, Bytes, BytesMut};
 
-use crate::error::AmqpParseError;
+use crate::{error::AmqpParseError, types::Constructor};
 
 macro_rules! decode_check_len {
     ($buf:ident, $size:expr) => {
@@ -14,26 +14,34 @@ macro_rules! decode_check_len {
 pub(crate) mod decode;
 mod encode;
 
-pub(crate) use self::decode::decode_list_header;
-
+/// Defines routines to encode the type as an AMQP value. Encoding must include the type constructor (format code or described type definition).
 pub trait Encode {
+    /// Returns the size of the type when encoded.
     fn encoded_size(&self) -> usize;
 
+    /// Encodes the type into the provided buffer.
     fn encode(&self, buf: &mut BytesMut);
 }
 
+/// Defines routines to encode the type as an element of an AMQP array. It's different from Encode in that it omits the type constructor
+/// (format code or described type definition) when encoding.
 pub trait ArrayEncode {
-    const ARRAY_FORMAT_CODE: u8;
+    const ARRAY_CONSTRUCTOR: Constructor;
 
+    /// Returns the size of the type when encoded as an element of an AMQP array.
     fn array_encoded_size(&self) -> usize;
 
+    /// Encodes the type as an element of an AMQP array.
     fn array_encode(&self, buf: &mut BytesMut);
 }
 
+/// Defines routines to decode the type from an encoded AMQP value representation. Decoding must handle parsing the type constructor
+/// (format code or described type definition).
 pub trait Decode
 where
     Self: Sized,
 {
+    /// Decodes the type from the provided buffer.
     fn decode(input: &mut Bytes) -> Result<Self, AmqpParseError>;
 }
 
@@ -42,10 +50,6 @@ where
     Self: Sized,
 {
     fn decode_with_format(input: &mut Bytes, fmt: u8) -> Result<Self, AmqpParseError>;
-}
-
-pub trait ArrayDecode: Sized {
-    fn array_decode(input: &mut Bytes) -> Result<Self, AmqpParseError>;
 }
 
 impl<T: DecodeFormatted> Decode for T {
@@ -57,51 +61,69 @@ impl<T: DecodeFormatted> Decode for T {
 
 pub fn decode_format_code(input: &mut Bytes) -> Result<u8, AmqpParseError> {
     decode_check_len!(input, 1);
-    let code = input[0];
-    input.split_to(1);
+    let code = input.get_u8();
     Ok(code)
 }
 
-pub const FORMATCODE_DESCRIBED: u8 = 0x00;
-pub const FORMATCODE_NULL: u8 = 0x40; // fixed width --V
-pub const FORMATCODE_BOOLEAN: u8 = 0x56;
-pub const FORMATCODE_BOOLEAN_TRUE: u8 = 0x41;
-pub const FORMATCODE_BOOLEAN_FALSE: u8 = 0x42;
-pub const FORMATCODE_UINT_0: u8 = 0x43;
-pub const FORMATCODE_ULONG_0: u8 = 0x44;
-pub const FORMATCODE_UBYTE: u8 = 0x50;
-pub const FORMATCODE_USHORT: u8 = 0x60;
-pub const FORMATCODE_UINT: u8 = 0x70;
-pub const FORMATCODE_ULONG: u8 = 0x80;
-pub const FORMATCODE_BYTE: u8 = 0x51;
-pub const FORMATCODE_SHORT: u8 = 0x61;
-pub const FORMATCODE_INT: u8 = 0x71;
-pub const FORMATCODE_LONG: u8 = 0x81;
-pub const FORMATCODE_SMALLUINT: u8 = 0x52;
-pub const FORMATCODE_SMALLULONG: u8 = 0x53;
-pub const FORMATCODE_SMALLINT: u8 = 0x54;
-pub const FORMATCODE_SMALLLONG: u8 = 0x55;
-pub const FORMATCODE_FLOAT: u8 = 0x72;
-pub const FORMATCODE_DOUBLE: u8 = 0x82;
-// pub const FORMATCODE_DECIMAL32: u8 = 0x74;
-// pub const FORMATCODE_DECIMAL64: u8 = 0x84;
-// pub const FORMATCODE_DECIMAL128: u8 = 0x94;
-pub const FORMATCODE_CHAR: u8 = 0x73;
-pub const FORMATCODE_TIMESTAMP: u8 = 0x83;
-pub const FORMATCODE_UUID: u8 = 0x98;
-pub const FORMATCODE_BINARY8: u8 = 0xa0; // variable --V
-pub const FORMATCODE_BINARY32: u8 = 0xb0;
-pub const FORMATCODE_STRING8: u8 = 0xa1;
-pub const FORMATCODE_STRING32: u8 = 0xb1;
-pub const FORMATCODE_SYMBOL8: u8 = 0xa3;
-pub const FORMATCODE_SYMBOL32: u8 = 0xb3;
-pub const FORMATCODE_LIST0: u8 = 0x45; // compound --V
-pub const FORMATCODE_LIST8: u8 = 0xc0;
-pub const FORMATCODE_LIST32: u8 = 0xd0;
-pub const FORMATCODE_MAP8: u8 = 0xc1;
-pub const FORMATCODE_MAP32: u8 = 0xd1;
-pub const FORMATCODE_ARRAY8: u8 = 0xe0;
-pub const FORMATCODE_ARRAY32: u8 = 0xf0;
+pub mod format_codes {
+    pub const FORMATCODE_DESCRIBED: u8 = 0x00;
+    pub const FORMATCODE_NULL: u8 = 0x40; // fixed width --V
+    pub const FORMATCODE_BOOLEAN: u8 = 0x56;
+    pub const FORMATCODE_BOOLEAN_TRUE: u8 = 0x41;
+    pub const FORMATCODE_BOOLEAN_FALSE: u8 = 0x42;
+    pub const FORMATCODE_UINT_0: u8 = 0x43;
+    pub const FORMATCODE_ULONG_0: u8 = 0x44;
+    pub const FORMATCODE_UBYTE: u8 = 0x50;
+    pub const FORMATCODE_USHORT: u8 = 0x60;
+    pub const FORMATCODE_UINT: u8 = 0x70;
+    pub const FORMATCODE_ULONG: u8 = 0x80;
+    pub const FORMATCODE_BYTE: u8 = 0x51;
+    pub const FORMATCODE_SHORT: u8 = 0x61;
+    pub const FORMATCODE_INT: u8 = 0x71;
+    pub const FORMATCODE_LONG: u8 = 0x81;
+    pub const FORMATCODE_SMALLUINT: u8 = 0x52;
+    pub const FORMATCODE_SMALLULONG: u8 = 0x53;
+    pub const FORMATCODE_SMALLINT: u8 = 0x54;
+    pub const FORMATCODE_SMALLLONG: u8 = 0x55;
+    pub const FORMATCODE_FLOAT: u8 = 0x72;
+    pub const FORMATCODE_DOUBLE: u8 = 0x82;
+    pub const FORMATCODE_DECIMAL32: u8 = 0x74;
+    pub const FORMATCODE_DECIMAL64: u8 = 0x84;
+    pub const FORMATCODE_DECIMAL128: u8 = 0x94;
+    pub const FORMATCODE_CHAR: u8 = 0x73;
+    pub const FORMATCODE_TIMESTAMP: u8 = 0x83;
+    pub const FORMATCODE_UUID: u8 = 0x98;
+    pub const FORMATCODE_BINARY8: u8 = 0xa0; // variable --V
+    pub const FORMATCODE_BINARY32: u8 = 0xb0;
+    pub const FORMATCODE_STRING8: u8 = 0xa1;
+    pub const FORMATCODE_STRING32: u8 = 0xb1;
+    pub const FORMATCODE_SYMBOL8: u8 = 0xa3;
+    pub const FORMATCODE_SYMBOL32: u8 = 0xb3;
+    pub const FORMATCODE_LIST0: u8 = 0x45; // compound --V
+    pub const FORMATCODE_LIST8: u8 = 0xc0;
+    pub const FORMATCODE_LIST32: u8 = 0xd0;
+    pub const FORMATCODE_MAP8: u8 = 0xc1;
+    pub const FORMATCODE_MAP32: u8 = 0xd1;
+    pub const FORMATCODE_ARRAY8: u8 = 0xe0;
+    pub const FORMATCODE_ARRAY32: u8 = 0xf0;
+}
+
+pub use self::format_codes::*;
+
+pub struct ListHeader {
+    pub size: u32,
+    pub count: u32,
+}
+
+pub struct MapHeader {
+    pub size: u32,
+    pub count: u32,
+}
+
+pub struct ArrayHeader {
+    pub size: u32,
+    pub count: u32,
+}
 
 #[cfg(test)]
 mod tests {

--- a/codec/src/lib.rs
+++ b/codec/src/lib.rs
@@ -12,7 +12,7 @@ mod message;
 pub mod protocol;
 pub mod types;
 
-pub use self::codec::{format_codes, ArrayEncode, Decode, DecodeFormatted, Encode};
+pub use self::codec::{format_codes, ArrayEncode, Decode, DecodeFormatted, Encode, ListHeader, MapHeader, ArrayHeader, decode_format_code};
 pub use self::error::{AmqpCodecError, AmqpParseError, ProtocolIdError};
 pub use self::framing::{AmqpFrame, SaslFrame};
 pub use self::io::{AmqpCodec, ProtocolIdCodec};

--- a/codec/src/lib.rs
+++ b/codec/src/lib.rs
@@ -12,11 +12,10 @@ mod message;
 pub mod protocol;
 pub mod types;
 
-pub use self::codec::{Decode, Encode};
+pub use self::codec::{format_codes, ArrayEncode, Decode, DecodeFormatted, Encode};
 pub use self::error::{AmqpCodecError, AmqpParseError, ProtocolIdError};
 pub use self::framing::{AmqpFrame, SaslFrame};
 pub use self::io::{AmqpCodec, ProtocolIdCodec};
 pub use self::message::{Message, MessageBody};
 
-/// A `HashMap` using a ahash::RandomState hasher.
 type HashMap<K, V> = std::collections::HashMap<K, V, fxhash::FxBuildHasher>;

--- a/codec/src/lib.rs
+++ b/codec/src/lib.rs
@@ -12,7 +12,9 @@ mod message;
 pub mod protocol;
 pub mod types;
 
-pub use self::codec::{format_codes, ArrayEncode, Decode, DecodeFormatted, Encode, ListHeader, MapHeader, ArrayHeader, decode_format_code};
+pub use self::codec::{
+    format_codes, ArrayEncode, ArrayHeader, Decode, DecodeFormatted, Encode, ListHeader, MapHeader,
+};
 pub use self::error::{AmqpCodecError, AmqpParseError, ProtocolIdError};
 pub use self::framing::{AmqpFrame, SaslFrame};
 pub use self::io::{AmqpCodec, ProtocolIdCodec};

--- a/codec/src/protocol/definitions.rs
+++ b/codec/src/protocol/definitions.rs
@@ -1,6 +1,6 @@
 #![allow(unused_assignments, unused_variables, unreachable_patterns)]
 use super::*;
-use crate::codec::{decode_format_code, decode_list_header};
+use crate::codec::{decode_format_code, ListHeader};
 use derive_more::From;
 #[derive(Clone, Debug, PartialEq, Eq, From)]
 pub enum Frame {
@@ -1084,7 +1084,7 @@ impl ErrorBuilder {
 #[allow(unused_mut)]
 fn decode_error_inner(input: &mut Bytes) -> Result<Error, AmqpParseError> {
     let format = decode_format_code(input)?;
-    let header = decode_list_header(input, format)?;
+    let header = ListHeader::decode_with_format(input, format)?;
     let size = header.size as usize;
     decode_check_len!(input, size);
     let mut data = input.split_to(size);
@@ -1345,7 +1345,7 @@ impl OpenBuilder {
 #[allow(unused_mut)]
 fn decode_open_inner(input: &mut Bytes) -> Result<Open, AmqpParseError> {
     let format = decode_format_code(input)?;
-    let header = decode_list_header(input, format)?;
+    let header = ListHeader::decode_with_format(input, format)?;
     let size = header.size as usize;
     decode_check_len!(input, size);
     let mut data = input.split_to(size);
@@ -1657,7 +1657,7 @@ impl BeginBuilder {
 #[allow(unused_mut)]
 fn decode_begin_inner(input: &mut Bytes) -> Result<Begin, AmqpParseError> {
     let format = decode_format_code(input)?;
-    let header = decode_list_header(input, format)?;
+    let header = ListHeader::decode_with_format(input, format)?;
     let size = header.size as usize;
     decode_check_len!(input, size);
     let mut data = input.split_to(size);
@@ -2032,7 +2032,7 @@ impl AttachBuilder {
 #[allow(unused_mut)]
 fn decode_attach_inner(input: &mut Bytes) -> Result<Attach, AmqpParseError> {
     let format = decode_format_code(input)?;
-    let header = decode_list_header(input, format)?;
+    let header = ListHeader::decode_with_format(input, format)?;
     let size = header.size as usize;
     decode_check_len!(input, size);
     let mut data = input.split_to(size);
@@ -2433,7 +2433,7 @@ impl FlowBuilder {
 #[allow(unused_mut)]
 fn decode_flow_inner(input: &mut Bytes) -> Result<Flow, AmqpParseError> {
     let format = decode_format_code(input)?;
-    let header = decode_list_header(input, format)?;
+    let header = ListHeader::decode_with_format(input, format)?;
     let size = header.size as usize;
     decode_check_len!(input, size);
     let mut data = input.split_to(size);
@@ -2803,7 +2803,7 @@ impl TransferBuilder {
 #[allow(unused_mut)]
 fn decode_transfer_inner(input: &mut Bytes) -> Result<Transfer, AmqpParseError> {
     let format = decode_format_code(input)?;
-    let header = decode_list_header(input, format)?;
+    let header = ListHeader::decode_with_format(input, format)?;
     let size = header.size as usize;
     decode_check_len!(input, size);
     let mut data = input.split_to(size);
@@ -3103,7 +3103,7 @@ impl DispositionBuilder {
 #[allow(unused_mut)]
 fn decode_disposition_inner(input: &mut Bytes) -> Result<Disposition, AmqpParseError> {
     let format = decode_format_code(input)?;
-    let header = decode_list_header(input, format)?;
+    let header = ListHeader::decode_with_format(input, format)?;
     let size = header.size as usize;
     decode_check_len!(input, size);
     let mut data = input.split_to(size);
@@ -3295,7 +3295,7 @@ impl DetachBuilder {
 #[allow(unused_mut)]
 fn decode_detach_inner(input: &mut Bytes) -> Result<Detach, AmqpParseError> {
     let format = decode_format_code(input)?;
-    let header = decode_list_header(input, format)?;
+    let header = ListHeader::decode_with_format(input, format)?;
     let size = header.size as usize;
     decode_check_len!(input, size);
     let mut data = input.split_to(size);
@@ -3404,7 +3404,7 @@ impl End {
 #[allow(unused_mut)]
 fn decode_end_inner(input: &mut Bytes) -> Result<End, AmqpParseError> {
     let format = decode_format_code(input)?;
-    let header = decode_list_header(input, format)?;
+    let header = ListHeader::decode_with_format(input, format)?;
     let size = header.size as usize;
     decode_check_len!(input, size);
     let mut data = input.split_to(size);
@@ -3485,7 +3485,7 @@ impl Close {
 #[allow(unused_mut)]
 fn decode_close_inner(input: &mut Bytes) -> Result<Close, AmqpParseError> {
     let format = decode_format_code(input)?;
-    let header = decode_list_header(input, format)?;
+    let header = ListHeader::decode_with_format(input, format)?;
     let size = header.size as usize;
     decode_check_len!(input, size);
     let mut data = input.split_to(size);
@@ -3566,7 +3566,7 @@ impl SaslMechanisms {
 #[allow(unused_mut)]
 fn decode_sasl_mechanisms_inner(input: &mut Bytes) -> Result<SaslMechanisms, AmqpParseError> {
     let format = decode_format_code(input)?;
-    let header = decode_list_header(input, format)?;
+    let header = ListHeader::decode_with_format(input, format)?;
     let size = header.size as usize;
     decode_check_len!(input, size);
     let mut data = input.split_to(size);
@@ -3670,7 +3670,7 @@ impl SaslInit {
 #[allow(unused_mut)]
 fn decode_sasl_init_inner(input: &mut Bytes) -> Result<SaslInit, AmqpParseError> {
     let format = decode_format_code(input)?;
-    let header = decode_list_header(input, format)?;
+    let header = ListHeader::decode_with_format(input, format)?;
     let size = header.size as usize;
     decode_check_len!(input, size);
     let mut data = input.split_to(size);
@@ -3778,7 +3778,7 @@ impl SaslChallenge {
 #[allow(unused_mut)]
 fn decode_sasl_challenge_inner(input: &mut Bytes) -> Result<SaslChallenge, AmqpParseError> {
     let format = decode_format_code(input)?;
-    let header = decode_list_header(input, format)?;
+    let header = ListHeader::decode_with_format(input, format)?;
     let size = header.size as usize;
     decode_check_len!(input, size);
     let mut data = input.split_to(size);
@@ -3860,7 +3860,7 @@ impl SaslResponse {
 #[allow(unused_mut)]
 fn decode_sasl_response_inner(input: &mut Bytes) -> Result<SaslResponse, AmqpParseError> {
     let format = decode_format_code(input)?;
-    let header = decode_list_header(input, format)?;
+    let header = ListHeader::decode_with_format(input, format)?;
     let size = header.size as usize;
     decode_check_len!(input, size);
     let mut data = input.split_to(size);
@@ -3951,7 +3951,7 @@ impl SaslOutcome {
 #[allow(unused_mut)]
 fn decode_sasl_outcome_inner(input: &mut Bytes) -> Result<SaslOutcome, AmqpParseError> {
     let format = decode_format_code(input)?;
-    let header = decode_list_header(input, format)?;
+    let header = ListHeader::decode_with_format(input, format)?;
     let size = header.size as usize;
     decode_check_len!(input, size);
     let mut data = input.split_to(size);
@@ -4134,7 +4134,7 @@ impl Source {
 #[allow(unused_mut)]
 fn decode_source_inner(input: &mut Bytes) -> Result<Source, AmqpParseError> {
     let format = decode_format_code(input)?;
-    let header = decode_list_header(input, format)?;
+    let header = ListHeader::decode_with_format(input, format)?;
     let size = header.size as usize;
     decode_check_len!(input, size);
     let mut data = input.split_to(size);
@@ -4387,7 +4387,7 @@ impl Target {
 #[allow(unused_mut)]
 fn decode_target_inner(input: &mut Bytes) -> Result<Target, AmqpParseError> {
     let format = decode_format_code(input)?;
-    let header = decode_list_header(input, format)?;
+    let header = ListHeader::decode_with_format(input, format)?;
     let size = header.size as usize;
     decode_check_len!(input, size);
     let mut data = input.split_to(size);
@@ -4578,7 +4578,7 @@ impl Header {
 #[allow(unused_mut)]
 fn decode_header_inner(input: &mut Bytes) -> Result<Header, AmqpParseError> {
     let format = decode_format_code(input)?;
-    let header = decode_list_header(input, format)?;
+    let header = ListHeader::decode_with_format(input, format)?;
     let size = header.size as usize;
     decode_check_len!(input, size);
     let mut data = input.split_to(size);
@@ -4819,7 +4819,7 @@ impl Properties {
 #[allow(unused_mut)]
 fn decode_properties_inner(input: &mut Bytes) -> Result<Properties, AmqpParseError> {
     let format = decode_format_code(input)?;
-    let header = decode_list_header(input, format)?;
+    let header = ListHeader::decode_with_format(input, format)?;
     let size = header.size as usize;
     decode_check_len!(input, size);
     let mut data = input.split_to(size);
@@ -5045,7 +5045,7 @@ impl Received {
 #[allow(unused_mut)]
 fn decode_received_inner(input: &mut Bytes) -> Result<Received, AmqpParseError> {
     let format = decode_format_code(input)?;
-    let header = decode_list_header(input, format)?;
+    let header = ListHeader::decode_with_format(input, format)?;
     let size = header.size as usize;
     decode_check_len!(input, size);
     let mut data = input.split_to(size);
@@ -5129,10 +5129,10 @@ impl Accepted {
 #[allow(unused_mut)]
 fn decode_accepted_inner(input: &mut Bytes) -> Result<Accepted, AmqpParseError> {
     let format = decode_format_code(input)?;
-    let header = decode_list_header(input, format)?;
+    let header = ListHeader::decode_with_format(input, format)?;
     let size = header.size as usize;
     decode_check_len!(input, size);
-    input.split_to(size);
+    input.advance(size);
     Ok(Accepted {})
 }
 fn encoded_size_accepted_inner(list: &Accepted) -> usize {
@@ -5201,7 +5201,7 @@ impl Rejected {
 #[allow(unused_mut)]
 fn decode_rejected_inner(input: &mut Bytes) -> Result<Rejected, AmqpParseError> {
     let format = decode_format_code(input)?;
-    let header = decode_list_header(input, format)?;
+    let header = ListHeader::decode_with_format(input, format)?;
     let size = header.size as usize;
     decode_check_len!(input, size);
     let mut data = input.split_to(size);
@@ -5272,10 +5272,10 @@ impl Released {
 #[allow(unused_mut)]
 fn decode_released_inner(input: &mut Bytes) -> Result<Released, AmqpParseError> {
     let format = decode_format_code(input)?;
-    let header = decode_list_header(input, format)?;
+    let header = ListHeader::decode_with_format(input, format)?;
     let size = header.size as usize;
     decode_check_len!(input, size);
-    input.split_to(size);
+    input.advance(size);
     Ok(Released {})
 }
 fn encoded_size_released_inner(list: &Released) -> usize {
@@ -5362,7 +5362,7 @@ impl Modified {
 #[allow(unused_mut)]
 fn decode_modified_inner(input: &mut Bytes) -> Result<Modified, AmqpParseError> {
     let format = decode_format_code(input)?;
-    let header = decode_list_header(input, format)?;
+    let header = ListHeader::decode_with_format(input, format)?;
     let size = header.size as usize;
     decode_check_len!(input, size);
     let mut data = input.split_to(size);

--- a/codec/src/protocol/mod.rs
+++ b/codec/src/protocol/mod.rs
@@ -3,27 +3,18 @@ use std::fmt;
 
 use chrono::{DateTime, Utc};
 use derive_more::From;
-use ntex_bytes::{BufMut, ByteString, Bytes, BytesMut};
+use ntex_bytes::{Buf, BufMut, ByteString, Bytes, BytesMut};
 use uuid::Uuid;
 
-use super::codec::{self, Decode, DecodeFormatted, Encode};
-use crate::{error::AmqpParseError, message::Message, types::*, HashMap};
+use crate::codec::{self, Decode, DecodeFormatted, Encode};
+use crate::types::{
+    Descriptor, List, Multiple, StaticSymbol, Str, Symbol, Variant, VecStringMap, VecSymbolMap,
+};
+use crate::{error::AmqpParseError, message::Message, HashMap};
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{self:?}")
-    }
-}
-
-#[derive(Debug)]
-pub(crate) struct CompoundHeader {
-    pub size: u32,
-    pub count: u32,
-}
-
-impl CompoundHeader {
-    pub fn empty() -> CompoundHeader {
-        CompoundHeader { size: 0, count: 0 }
     }
 }
 
@@ -52,15 +43,11 @@ pub type Annotations = HashMap<Symbol, Variant>;
 mod definitions;
 pub use self::definitions::*;
 
-#[derive(Debug, Eq, PartialEq, Clone, From, Display)]
+#[derive(Debug, Eq, PartialEq, Clone, From)]
 pub enum MessageId {
-    #[display("{}", _0)]
     Ulong(u64),
-    #[display("{}", _0)]
     Uuid(Uuid),
-    #[display("{:?}", _0)]
     Binary(Bytes),
-    #[display("{}", _0)]
     String(ByteString),
 }
 

--- a/codec/src/types/array.rs
+++ b/codec/src/types/array.rs
@@ -88,10 +88,10 @@ impl Encode for Array {
 impl DecodeFormatted for Array {
     fn decode_with_format(input: &mut Bytes, fmt: u8) -> Result<Self, AmqpParseError> {
         let header = ArrayHeader::decode_with_format(input, fmt)?;
-        let size = header.size as usize - 1;
-        let element_constructor = Constructor::decode(input)?;
+        let size = header.size as usize;
         decode_check_len!(input, size);
-        let payload = input.split_to(size);
+        let mut payload = input.split_to(size);
+        let element_constructor = Constructor::decode(&mut payload)?;
 
         Ok(Array {
             element_constructor,

--- a/codec/src/types/array.rs
+++ b/codec/src/types/array.rs
@@ -1,12 +1,13 @@
 use ntex_bytes::{BufMut, Bytes, BytesMut};
 
-use crate::codec::{self, decode, ArrayEncode, DecodeFormatted, Encode};
+use crate::codec::{self, ArrayEncode, ArrayHeader, Decode, DecodeFormatted, Encode};
 use crate::error::AmqpParseError;
+use crate::types::Constructor;
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub struct Array {
-    len: u32,
-    format: u8,
+    count: u32,
+    element_constructor: Constructor,
     payload: Bytes,
 }
 
@@ -24,17 +25,23 @@ impl Array {
         }
 
         Array {
-            len,
+            count: len,
             payload: buf.freeze(),
-            format: T::ARRAY_FORMAT_CODE,
+            element_constructor: T::ARRAY_CONSTRUCTOR,
         }
     }
 
+    pub fn element_constructor(&self) -> &Constructor {
+        &self.element_constructor
+    }
+
+    /// Attempts to decode the array into a vector of type `T`. Format code supplied to T::decode_with_format is the format code of the underlying
+    /// AMQP type of array's element constructor. Use `Array::element_constructor` to access full constructor if needed.
     pub fn decode<T: DecodeFormatted>(&self) -> Result<Vec<T>, AmqpParseError> {
         let mut buf = self.payload.clone();
-        let mut result: Vec<T> = Vec::with_capacity(self.len as usize);
-        for _ in 0..self.len {
-            let decoded = T::decode_with_format(&mut buf, self.format)?;
+        let mut result: Vec<T> = Vec::with_capacity(self.count as usize);
+        for _ in 0..self.count {
+            let decoded = T::decode_with_format(&mut buf, self.element_constructor.format_code())?;
             result.push(decoded);
         }
         Ok(result)
@@ -52,44 +59,44 @@ where
 
 impl Encode for Array {
     fn encoded_size(&self) -> usize {
-        // format_code + size + count + item constructor -- todo: support described ctor?
-        (if self.payload.len() + 1 > u8::MAX as usize {
-            10
+        let ctor_len = self.element_constructor.encoded_size();
+        let header_len = if self.payload.len() + ctor_len + 1 > u8::MAX as usize {
+            9 // 1 for format code, 4 for size, 4 for count
         } else {
-            4
-        }) // +1 for 1 byte count and 1 byte format code
-            + self.payload.len()
+            3 // 1 for format code, 1 for size, 1 for count
+        };
+
+        header_len + ctor_len + self.payload.len()
     }
 
     fn encode(&self, buf: &mut BytesMut) {
-        if self.payload.len() + 1 > u8::MAX as usize {
+        let ctor_len = self.element_constructor.encoded_size();
+        if self.payload.len() + ctor_len + 1 > u8::MAX as usize {
             buf.put_u8(codec::FORMATCODE_ARRAY32);
-            buf.put_u32((self.payload.len() + 5) as u32); // +4 for 4 byte count and 1 byte item ctor that follow
-            buf.put_u32(self.len);
+            buf.put_u32((4 + ctor_len + self.payload.len()) as u32); // size. 4 for count
+            buf.put_u32(self.count);
         } else {
             buf.put_u8(codec::FORMATCODE_ARRAY8);
-            buf.put_u8((self.payload.len() + 2) as u8); // +1 for 1 byte count and 1 byte item ctor that follow
-            buf.put_u8(self.len as u8);
+            buf.put_u8((1 + ctor_len + self.payload.len()) as u8); // size. 1 for count
+            buf.put_u8(self.count as u8);
         }
-        buf.put_u8(self.format);
-        buf.extend_from_slice(&self.payload[..]);
+        self.element_constructor.encode(buf);
+        buf.extend_from_slice(self.payload.as_ref());
     }
 }
 
 impl DecodeFormatted for Array {
     fn decode_with_format(input: &mut Bytes, fmt: u8) -> Result<Self, AmqpParseError> {
-        let header = decode::decode_array_header(input, fmt)?;
-        decode_check_len!(input, 1);
+        let header = ArrayHeader::decode_with_format(input, fmt)?;
         let size = header.size as usize - 1;
-        let format = input[0]; // todo: support descriptor
-        input.split_to(1);
+        let element_constructor = Constructor::decode(input)?;
         decode_check_len!(input, size);
         let payload = input.split_to(size);
 
         Ok(Array {
-            format,
+            element_constructor,
             payload,
-            len: header.count,
+            count: header.count,
         })
     }
 }

--- a/codec/src/types/mod.rs
+++ b/codec/src/types/mod.rs
@@ -8,12 +8,30 @@ mod variant;
 
 pub use self::array::Array;
 pub use self::symbol::{StaticSymbol, Symbol};
-pub use self::variant::{Variant, VariantMap, VecStringMap, VecSymbolMap};
+pub use self::variant::{DescribedCompound, Variant, VariantMap, VecStringMap, VecSymbolMap};
 
-#[derive(Debug, PartialEq, Eq, Clone, Hash, Display)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub enum Descriptor {
     Ulong(u64),
     Symbol(Symbol),
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+pub enum Constructor {
+    FormatCode(u8),
+    Described {
+        descriptor: Descriptor,
+        format_code: u8,
+    },
+}
+
+impl Constructor {
+    pub fn format_code(&self) -> u8 {
+        match self {
+            Constructor::FormatCode(code) => *code,
+            Constructor::Described { format_code, .. } => *format_code,
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, From)]
@@ -76,87 +94,63 @@ impl From<Vec<Variant>> for List {
     }
 }
 
-#[derive(Display, Clone, Eq, Ord, PartialOrd)]
-pub enum Str {
-    String(String),
-    ByteStr(ByteString),
-    Static(&'static str),
-}
+#[derive(Clone, Eq, Ord, PartialOrd, PartialEq)]
+pub struct Str(ByteString);
 
 impl Str {
     #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Str {
-        Str::ByteStr(ByteString::from(s))
+        Str(ByteString::from(s))
     }
 
     pub const fn from_static(s: &'static str) -> Str {
-        Str::Static(s)
+        Str(ByteString::from_static(s))
     }
 
     pub fn as_bytes(&self) -> &[u8] {
-        match self {
-            Str::String(s) => s.as_ref(),
-            Str::ByteStr(s) => s.as_ref().as_ref(),
-            Str::Static(s) => s.as_bytes(),
-        }
+        self.0.as_bytes().as_ref()
     }
 
     pub fn as_str(&self) -> &str {
-        match self {
-            Str::String(s) => s.as_str(),
-            Str::ByteStr(s) => s.as_ref(),
-            Str::Static(s) => s,
-        }
+        self.0.as_str()
     }
 
     pub fn to_bytes_str(&self) -> ByteString {
-        match self {
-            Str::String(s) => ByteString::from(s.as_str()),
-            Str::ByteStr(s) => s.clone(),
-            Str::Static(s) => ByteString::from_static(s),
-        }
+        self.0.clone()
     }
 
     pub fn len(&self) -> usize {
-        match self {
-            Str::String(s) => s.len(),
-            Str::ByteStr(s) => s.len(),
-            Str::Static(s) => s.len(),
-        }
+        self.0.len()
     }
 }
 
 impl From<&'static str> for Str {
     fn from(s: &'static str) -> Str {
-        Str::Static(s)
+        Str(ByteString::from_static(s))
     }
 }
 
 impl From<ByteString> for Str {
     fn from(s: ByteString) -> Str {
-        Str::ByteStr(s)
+        Str(s)
     }
 }
 
 impl From<String> for Str {
     fn from(s: String) -> Str {
-        Str::String(s)
+        Str(ByteString::from(s))
     }
 }
 
 impl<'a> From<&'a ByteString> for Str {
     fn from(s: &'a ByteString) -> Str {
-        Str::ByteStr(s.clone())
+        Str(s.clone())
     }
 }
 
 impl hash::Hash for Str {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
-        match self {
-            Str::String(s) => (**s).hash(state),
-            Str::ByteStr(s) => (**s).hash(state),
-            Str::Static(s) => s.hash(state),
-        }
+        self.0.hash(state);
     }
 }
 
@@ -166,48 +160,14 @@ impl borrow::Borrow<str> for Str {
     }
 }
 
-impl PartialEq<Str> for Str {
-    fn eq(&self, other: &Str) -> bool {
-        match self {
-            Str::String(s) => match other {
-                Str::String(o) => s == o,
-                Str::ByteStr(o) => o == s.as_str(),
-                Str::Static(o) => s == *o,
-            },
-            Str::ByteStr(s) => match other {
-                Str::String(o) => s == o.as_str(),
-                Str::ByteStr(o) => s == o,
-                Str::Static(o) => s == *o,
-            },
-            Str::Static(s) => match other {
-                Str::String(o) => o == s,
-                Str::ByteStr(o) => o == *s,
-                Str::Static(o) => s == o,
-            },
-        }
-    }
-}
-
 impl PartialEq<str> for Str {
     fn eq(&self, other: &str) -> bool {
-        match self {
-            Str::String(ref s) => s == other,
-            Str::ByteStr(ref s) => {
-                // workaround for possible compiler bug
-                let t: &str = s;
-                t == other
-            }
-            Str::Static(s) => *s == other,
-        }
+        self.0.eq(&other)
     }
 }
 
 impl fmt::Debug for Str {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Str::String(s) => write!(f, "ST:\"{s}\""),
-            Str::ByteStr(s) => write!(f, "B:\"{s}\""),
-            Str::Static(s) => write!(f, "S:\"{s}\""),
-        }
+        self.0.fmt(f)
     }
 }

--- a/codec/src/types/symbol.rs
+++ b/codec/src/types/symbol.rs
@@ -4,16 +4,16 @@ use ntex_bytes::ByteString;
 
 use super::Str;
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Display)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct Symbol(pub Str);
 
 impl Symbol {
     pub const fn from_static(s: &'static str) -> Symbol {
-        Symbol(Str::Static(s))
+        Symbol(Str::from_static(s))
     }
 
     pub fn from_slice(s: &str) -> Symbol {
-        Symbol(Str::ByteStr(ByteString::from(s)))
+        Symbol(Str(ByteString::from(s)))
     }
 
     pub fn as_bytes(&self) -> &[u8] {
@@ -59,7 +59,7 @@ impl From<std::string::String> for Symbol {
 
 impl From<ByteString> for Symbol {
     fn from(s: ByteString) -> Symbol {
-        Symbol(Str::ByteStr(s))
+        Symbol(Str(s))
     }
 }
 
@@ -75,7 +75,7 @@ impl PartialEq<str> for Symbol {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Display)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct StaticSymbol(pub &'static str);
 
 impl StaticSymbol {

--- a/src/delivery.rs
+++ b/src/delivery.rs
@@ -222,7 +222,7 @@ impl Drop for Delivery {
 
             if !self.is_set(Flags::REMOTE_SETTLED) && !self.is_set(Flags::LOCAL_SETTLED) {
                 let err = Error::build()
-                    .condition(ErrorCondition::Custom(Symbol(Str::Static(
+                    .condition(ErrorCondition::Custom(Symbol(Str::from_static(
                         "Internal error",
                     ))))
                     .finish();

--- a/src/server/error.rs
+++ b/src/server/error.rs
@@ -1,31 +1,31 @@
-use derive_more::Display;
 use ntex::util::Either;
 
 use crate::codec::{protocol, AmqpCodecError, AmqpFrame, ProtocolIdError, SaslFrame};
 use crate::error::{AmqpDispatcherError, AmqpProtocolError};
 
 /// Errors which can occur when attempting to handle amqp connection.
-#[derive(Debug, Display)]
+#[derive(Debug, thiserror::Error)]
 pub enum ServerError<E> {
-    #[display("Message handler service error")]
+    #[error("Message handler service error")]
     /// Message handler service error
     Service(E),
-    #[display("Handshake error: {}", _0)]
+    #[error("Handshake error: {}", 0)]
     /// Amqp handshake error
     Handshake(HandshakeError),
     /// Amqp codec error
-    #[display("Amqp codec error: {:?}", _0)]
+    #[error("Amqp codec error: {:?}", 0)]
     Codec(AmqpCodecError),
     /// Amqp protocol error
-    #[display("Amqp protocol error: {:?}", _0)]
+    #[error("Amqp protocol error: {:?}", 0)]
     Protocol(AmqpProtocolError),
     /// Dispatcher error
+    #[error("Amqp dispatcher error: {:?}", 0)]
     Dispatcher(AmqpDispatcherError),
     /// Control service init error
-    #[display("Control service init error")]
+    #[error("Control service init error")]
     ControlServiceError,
     /// Publish service init error
-    #[display("Publish service init error")]
+    #[error("Publish service init error")]
     PublishServiceError,
 }
 
@@ -48,38 +48,36 @@ impl<E> From<HandshakeError> for ServerError<E> {
 }
 
 /// Errors which can occur when attempting to handle amqp handshake.
-#[derive(Debug, Display, From)]
+#[derive(Debug, From, thiserror::Error)]
 pub enum HandshakeError {
     /// Amqp codec error
-    #[display("Amqp codec error: {:?}", _0)]
+    #[error("Amqp codec error: {:?}", 0)]
     Codec(AmqpCodecError),
     /// Handshake timeout
-    #[display("Handshake timeout")]
+    #[error("Handshake timeout")]
     Timeout,
     /// Protocol negotiation error
-    #[display("Peer disconnected")]
+    #[error("Peer disconnected")]
     ProtocolNegotiation(ProtocolIdError),
     #[from(ignore)]
     /// Expected open frame
-    #[display("Expect open frame, got: {:?}", _0)]
+    #[error("Expect open frame, got: {:?}", 0)]
     ExpectOpenFrame(AmqpFrame),
-    #[display("Unexpected frame, got: {:?}", _0)]
+    #[error("Unexpected frame, got: {:?}", 0)]
     Unexpected(protocol::Frame),
-    #[display("Unexpected sasl frame: {:?}", _0)]
+    #[error("Unexpected sasl frame: {:?}", 0)]
     UnexpectedSaslFrame(Box<SaslFrame>),
-    #[display("Unexpected sasl frame body: {:?}", _0)]
+    #[error("Unexpected sasl frame body: {:?}", 0)]
     UnexpectedSaslBodyFrame(Box<protocol::SaslFrameBody>),
-    #[display("Unsupported sasl mechanism: {}", _0)]
+    #[error("Unsupported sasl mechanism: {}", 0)]
     UnsupportedSaslMechanism(String),
     /// Sasl error code
-    #[display("Sasl error code: {:?}", _0)]
+    #[error("Sasl error code: {:?}", 0)]
     Sasl(protocol::SaslCode),
     /// Unexpected io error, peer disconnected
-    #[display("Peer disconnected, with error {:?}", _0)]
+    #[error("Peer disconnected, with error {:?}", 0)]
     Disconnected(Option<std::io::Error>),
 }
-
-impl std::error::Error for HandshakeError {}
 
 impl From<Either<AmqpCodecError, std::io::Error>> for HandshakeError {
     fn from(err: Either<AmqpCodecError, std::io::Error>) -> Self {


### PR DESCRIPTION
- better expose routines for encoding/decoding custom structures outside of ntex-amqp itself
- removed Display impl from some types
- added support for element constructors with descriptor in array encoding
- added explicit failure on Vec and Multiple decoding if element constructor is a described type
- added nominal representation for decimal primitive types
- simplified Str to ByteString internal representation
- thiserror::Error impl for some error types